### PR TITLE
Experimental push on scalar is now forbidden

### DIFF
--- a/260babel.pl
+++ b/260babel.pl
@@ -1009,7 +1009,7 @@ sub calc_poi($)
 		{
 			my $p={};
 			$p->{name}=substr($_->{name},0,14);
-			push $track->{pois},$p;
+			push @{$track->{pois}},$p;
 		}
 	}
 }
@@ -1077,7 +1077,7 @@ sub open_gpx_file
 					$p->{name}=$1 if (m/<name>([^<]+)<\/name>/s);
 					$p->{speed}=$1 if (m/<speed>([^<]+)<\/speed/s);
 					$p->{speed}//=10;
-					push $t->{points},$p if(defined ($p->{lon} && defined($p->{lat})));
+					push @{$t->{points}},$p if(defined ($p->{lon} && defined($p->{lat})));
 				}
 			}
 			push @TRACK,$t;


### PR DESCRIPTION

./260babel.pl                               
Experimental push on scalar is now forbidden at /home/mastier/.bin/260babel.pl line 1012, near "$p;"
Experimental push on scalar is now forbidden at /home/mastier/.bin/260babel.pl line 1080, near "$p if"

@Ubuntu 17.04
➜  ~ perl --version
This is perl 5, version 24, subversion 1 (v5.24.1) built for x86_64-linux-gnu-thread-multi
(with 67 registered patches, see perl -V for more detail)